### PR TITLE
docs: Fix a few typos

### DIFF
--- a/weixin2py/__init__.py
+++ b/weixin2py/__init__.py
@@ -82,7 +82,7 @@ class WeiMsg(object):
         self.event_key = self.get_info(re_eventkey, msg)
 
     def __init__(self, msg):
-        """genetate a message object
+        """generate a message object
         """
         self.to_user_name = self.get_info(re_msg_tuid, msg)
         self.from_user_name = self.get_info(re_msg_fuid, msg)

--- a/weixin2py/plugin/setting.py
+++ b/weixin2py/plugin/setting.py
@@ -4,7 +4,7 @@
 #ver 0.1 by winkidney 2014.05.10
 from . import activity
 
-#将在每个response返回之前运行，用于修改respose内容。
+#将在每个response返回之前运行，用于修改response内容。
 
 
 plugin_text = (activity,


### PR DESCRIPTION
There are small typos in:
- weixin2py/__init__.py
- weixin2py/plugin/setting.py

Fixes:
- Should read `response` rather than `respose`.
- Should read `generate` rather than `genetate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md